### PR TITLE
Fix missing } after function body in FF

### DIFF
--- a/core-layout-trbl.html
+++ b/core-layout-trbl.html
@@ -154,7 +154,7 @@ Renders something like this
 
       prepare: function() {
         var parent = this.parentNode.host || this.parentNode;
-        // explicit position harmful on <body>
+        // explicit position harmful on body
         if (parent.localName !== 'body') {
         // may recalc
           var cs = window.getComputedStyle(parent);


### PR DESCRIPTION
The <body> tags in the comment will cause a SyntaxError: missing } after function body in FF 32.0, changing this into body will solve the problem.